### PR TITLE
Add push to deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Allows authenticated or anonymous users to fill out a standard web form to create GitHub issues.
 
-[![Build Status](https://travis-ci.org/benbalter/problem_child.svg)](https://travis-ci.org/benbalter/problem_child)
+[![Build Status](https://travis-ci.org/benbalter/problem_child.svg)](https://travis-ci.org/benbalter/problem_child) [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 ## How it works
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,36 @@
+{
+  "name": "Problem Child",
+  "description": "Allows authenticated or anonymous users to fill out a standard web form to creat GitHub issues.",
+  "repository": "https://github.com/benbalter/problem_child",
+  "addons": [
+    "heroku-redis:hobby-dev"
+  ],
+  "env": {
+    "GITHUB_CLIENT_ID": {
+      "description": "The ID of your GitHub OAuth application, created via https://github.com/settings/applications/new",
+      "required": "true"
+    },
+    "GITHUB_CLIENT_SECRET": {
+      "description": "The secret key of your GitHub OAuth application, created via https://github.com/settings/applications/new",
+      "required": "true"
+    },
+    "GITHUB_REPO": {
+      "description": "The repository against which to open issues submitted via Problem Child",
+      "required": "true"
+    },
+    "GITHUB_TOKEN": {
+      "description": "A personal access token for a bot account with the ability to create an issue in the GITHUB_REPO if you would like all submissions to be anonymous"
+    },
+    "GITHUB_TEAM_ID": {
+      "description": "The GitHub Org ID e.g, @whitehouse if you'd like all users to authenticate against a GitHub Org prior to being presented the form"
+    },
+    "GITHUB_ORG_ID": {
+      "description": "The numeric Team ID (e.g., 1234) if you'd like all users to authenticate against a GitHub Team prior to being presented the form"
+    }
+  },
+  "buildpacks": [
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-ruby"
+    }
+  ]
+}

--- a/app.json
+++ b/app.json
@@ -27,10 +27,5 @@
     "GITHUB_ORG_ID": {
       "description": "The numeric Team ID (e.g., 1234) if you'd like all users to authenticate against a GitHub Team prior to being presented the form"
     }
-  },
-  "buildpacks": [
-    {
-      "url": "https://github.com/heroku/heroku-buildpack-ruby"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Add thus `app.json`. You'll still need to set `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and either `GITHUB_TOKEN`, `GITHUB_ORG_ID` or `GITHUB_TEAM_ID`. 

It's also not the recommended way of using problem child, because you'll be running from source, not from the Rubygems version. I suppose one could create a dummy/demo repo with a README, `app.json`, `Gemfile` and `config.ru` file, which'll get you 99% of the way there in a single click. Easy enough to vendor once it's here.

/cc @vzvenyach