### PR TITLE
Revert Recaptcha support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,6 @@ You must also set **one** of the following:
 * `GITHUB_ORG_ID` - The GitHub Org ID e.g, `@whitehouse` if you'd like all users to authenticate against a GitHub Org prior to being presented the form
 * `GITHUB_TEAM_ID` - The numeric Team ID (e.g., 1234) if you'd like all users to authenticate against a GitHub Team prior to being presented the form
 
-You can also set a variable to enable Google reCAPTCHA support:
-
-* `REACAPTCHA_SITE_KEY` - The key created for your reCAPTCHA site via https://www.google.com/recaptcha/admin
-
-If set, the Problem child default form will include a bit of JavaScript to test if the reCAPTCHA test was passed before submitting.
-
 *Pro-tip*: When developing locally, you can add these values to a `.env` file in the project root, and they will be automatically read in on load
 
 ## Customizing

--- a/lib/problem_child/helpers.rb
+++ b/lib/problem_child/helpers.rb
@@ -30,11 +30,7 @@ module ProblemChild
     end
 
     def issue_body
-      form_data.reject { |key, value|
-        key == "title" || value.empty? || key == "labels" || value.is_a?(Hash)
-      }.except( "g-recaptcha-response" ).map { |key, value|
-        "* **#{key.humanize}**: #{value}"
-      }.join("\n")
+      form_data.reject { |key, value| key == "title" || value.empty? || key == "labels" || value.is_a?(Hash) }.map { |key,value| "* **#{key.humanize}**: #{value}"}.join("\n")
     end
 
     # abstraction to allow cached form data to be used in place of default params

--- a/lib/problem_child/helpers.rb
+++ b/lib/problem_child/helpers.rb
@@ -17,10 +17,6 @@ module ProblemChild
       end
     end
 
-    def recaptcha
-      ENV["RECAPTCHA_SITE_KEY"] unless ENV["RECAPTCHA_SITE_KEY"].nil? || ENV["RECAPTCHA_SITE_KEY"].to_s.empty?
-    end
-
     def client
       @client ||= Octokit::Client.new :access_token => token
     end

--- a/lib/problem_child/views/form.erb
+++ b/lib/problem_child/views/form.erb
@@ -5,10 +5,6 @@
 <% end %>
 </h1>
 
-<div class="alert alert-warning alert-recaptcha hidden" role="alert">
-  Please verify that you are not a robot.
-</div>
-
 <% if issue %>
   <div class="alert alert-success" role="alert">
     Your issue was successfully submitted<% if access %> as <a href="http://github.com/<%= repo %>/issues/<%= issue %>"><%= repo %>#<%= issue %></a><% end %>.
@@ -30,10 +26,6 @@
     <label for="body">Body</label>
     <textarea class="form-control" rows="10" id="body" name="body"></textarea>
   </div>
-
-  <% if recaptcha.present? %>
-    <div class="g-recaptcha" data-sitekey="<%= recaptcha %>"></div>
-  <% end %>
 
   <button type="submit" class="btn btn-default">Submit</button>
 </form>

--- a/lib/problem_child/views/layout.erb
+++ b/lib/problem_child/views/layout.erb
@@ -16,13 +16,6 @@
   <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
   <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
   <![endif]-->
-
-  <% if recaptcha.present? %>
-    <script src='https://www.google.com/recaptcha/api.js'></script>
-  <% end %>
-
-  <script src='https://www.google.com/recaptcha/api.js'></script>
-
 </head>
 <body>
   <div class="container">
@@ -30,25 +23,5 @@
     <%= yield %>
 
   </div>
-
-  <% if recaptcha.present? %>
-    <script src="/vendor/jquery/dist/jquery.min.js"></script>
-
-    <script>
-  $( 'form' ).submit( function( e ) {
-    var prevent = false;
-
-    if ( !grecaptcha.getResponse() ) {
-      $( '.alert-recaptcha' ).removeClass( 'hidden' );
-      prevent = true;
-    }
-
-    if ( prevent ) {
-      e.preventDefault();
-      return false;
-    }
-  } );
-    </script>
-  <% end %>
 </body>
 </html>


### PR DESCRIPTION
I didn't see that these snuck in accidentally as part of #9.

As I mentioned in https://github.com/benbalter/problem_child/issues/11, https://github.com/benbalter/comment-card, which is based on problem child, provides native (server side) recaptcha support. A purely client side implementation is easily bypassed.

I'd like to keep problem child as close to a server with a reference implementation as possible, and make it easy for users to customize to particular use cases (e.g., like comment card easily adding captcha support).

@ryanttb thanks again for all your pull requests. They are very greatly appreciated and hope you find the project helpful. If you have any other features you'd like to implement, I'd be more than glad to work on them with you. :smile_cat: 

/cc #11, @ryanttb 